### PR TITLE
bug in session library

### DIFF
--- a/libs/session/session.php
+++ b/libs/session/session.php
@@ -150,7 +150,6 @@ class Session
 		//check before setting data, if the session has expired.
 		if($this->inactivityTimeout() || $this->expireTimeout())
 		{
-			echo "<BR>Session Timeout<BR>";
 			$this->refreshSession();
 		}
 
@@ -182,7 +181,6 @@ class Session
 		//check before retrieving data, if the session has expired.
 		if($this->inactivityTimeout() || $this->expireTimeout())
 		{
-			echo "<BR>Session Timeout<BR>";
 			$this->refreshSession();
 		}
 


### PR DESCRIPTION
there is a little bug in session I believe in session library, have a look 
I don't think there is need to display an error message in that function 
