### PR TITLE
adding host (ommitted) parameter

### DIFF
--- a/libs/db/adapter/pdo_mysql.php
+++ b/libs/db/adapter/pdo_mysql.php
@@ -31,7 +31,7 @@ class Database_pdo_mysql extends DatabaseModel
 
 		if (count($args) > 1)	//If more than one argument are present, then create a new PDO object
 		{
-			$dbConfig = new DatabaseConfig ('pdo_mysql', $args[0], $args[1], $args[2]);	//get a new DB configuration
+			$dbConfig = new DatabaseConfig ('pdo_mysql', $args[0], $args[1], $args[2],$args[3]);	//get a new DB configuration
 			parent::__construct($dbConfig);		//call the DatabaseModel's constructor to pass the DatabaseConfig object to initialize a new object
 			$this->dbh = new \PDO ("mysql:dbname={$dbConfig->dbname};host={$dbConfig->host};", $dbConfig->username, $dbConfig->password);	//create a new PDO object
 		}


### PR DESCRIPTION
The host parameter ( args[3]) is locked to 127.0.0.1, because it is not used here.
When the database host is not on 127.0.0.1 or the IP is not authorized the database connection fails.
