### PR TITLE
Careful with >=

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {   
-	"require-dev": {
-        "satooshi/php-coveralls": ">=0.6"
+    "require-dev": {
+        "satooshi/php-coveralls": "0.6.*"
     }
 }


### PR DESCRIPTION
The trouble with using `>=` like that is two-fold.

1. According to SemVer, 0.7.0 could have breaking changes, which can cause trouble
2. It will include v1.0, which could be very different

I stick to `0.x.*` until 1.0 is out, then switch to `~1.0`.

Also ya'll had some messy tab/space combination.