### PR TITLE
Correct csrf and random

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {   
 	"require-dev": {
         "satooshi/php-coveralls": ">=0.6"
-    }
+    },
+	"require": {
+		"paragonie/random_compat": "^1.1"
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,60 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "1dcf5aaf0f761f5655a38824a2b9be29",
+    "hash": "2e06de680bfbe376b1b2828f71293d19",
+    "content-hash": "3796801e289196cfea597d743127a2b2",
     "packages": [
-
+        {
+            "name": "paragonie/random_compat",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "19f765b66c6fbb56ee3b11bc16d52e38eebdc295"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/19f765b66c6fbb56ee3b11bc16d52e38eebdc295",
+                "reference": "19f765b66c6fbb56ee3b11bc16d52e38eebdc295",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2015-11-10 00:45:41"
+        }
     ],
     "packages-dev": [
         {
@@ -212,12 +261,12 @@
             "target-dir": "Symfony/Component/Config",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "2effc67af6f21a0d267210b72d0b0b691d113528"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/2effc67af6f21a0d267210b72d0b0b691d113528",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2effc67af6f21a0d267210b72d0b0b691d113528",
                 "reference": "2effc67af6f21a0d267210b72d0b0b691d113528",
                 "shasum": ""
             },
@@ -262,12 +311,12 @@
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "2e452005b1e1d003d23702d227e23614679eb5ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/2e452005b1e1d003d23702d227e23614679eb5ca",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2e452005b1e1d003d23702d227e23614679eb5ca",
                 "reference": "2e452005b1e1d003d23702d227e23614679eb5ca",
                 "shasum": ""
             },
@@ -317,12 +366,12 @@
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
                 "reference": "e539602e5455aa086c0e81e604745af7789e4d8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/e539602e5455aa086c0e81e604745af7789e4d8a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e539602e5455aa086c0e81e604745af7789e4d8a",
                 "reference": "e539602e5455aa086c0e81e604745af7789e4d8a",
                 "shasum": ""
             },
@@ -373,12 +422,12 @@
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "a3af8294bcce4a7c1b2892363b0c9d8109affad4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a3af8294bcce4a7c1b2892363b0c9d8109affad4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a3af8294bcce4a7c1b2892363b0c9d8109affad4",
                 "reference": "a3af8294bcce4a7c1b2892363b0c9d8109affad4",
                 "shasum": ""
             },
@@ -515,17 +564,11 @@
             "time": "2014-04-18 20:37:09"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
-    "platform": [
-
-    ],
-    "platform-dev": [
-
-    ]
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
 }

--- a/libs/core/random.php
+++ b/libs/core/random.php
@@ -1,6 +1,6 @@
 <?php
-namespace phpsec;
 
+namespace phpsec;
 
 /**
  * Function to generate a random number of specified range.
@@ -16,7 +16,6 @@ function rand($min = 0, $max = null)
     return Rand::randRange($min, $max);
 }
 
-
 /**
  * Function to generata a random string of specified length.
  * @param int $len
@@ -27,56 +26,17 @@ function randstr($len = 32)
     return Rand::randStr($len);
 }
 
-
-class Rand
+final class Rand
 {
-
-    /**
-     * The seed from which a random number will be generated.
-     * @var int
-     */
-    protected static $randomSeed=null;
-
-
-
     /**
      * Provides a random 32 bit number
-     * if openssl is available, it is cryptographically secure. Otherwise all available entropy is gathered.
+     *
      * @return number
      */
     public static function random()
     {
-        //If openssl is present, use that to generate random.
-        if (function_exists("openssl_random_pseudo_bytes") && FALSE)
-        {
-            $random32bit=(int)(hexdec(bin2hex(openssl_random_pseudo_bytes(64))));
-        }
-        else
-        {
-            if (self::$randomSeed===null)
-            {
-                $entropy=1;
-
-                if (function_exists("posix_getpid"))
-                    $entropy*=posix_getpid();
-
-                if (function_exists("memory_get_usage"))
-                    $entropy*=memory_get_usage();
-
-                list ($usec, $sec)=explode(" ",microtime());
-                $usec*=1000000;
-                $entropy*=$usec;
-                self::$randomSeed=$entropy;
-
-                mt_srand(self::$randomSeed);
-            }
-
-            $random32bit=mt_rand();
-        }
-
-        return $random32bit;
+        return self::randRange();
     }
-
 
     /**
      * To generate a random number between the specified range.
@@ -84,52 +44,18 @@ class Rand
      * @param int $max
      * @return number
      */
-    public static function randRange($min=0,$max=null)
+    public static function randRange($min = 0, $max = PHP_INT_MAX)
     {
-        if ($max===null)
-            $max=1<<31;
-
-        if ($min > $max)
-        {
-            return Rand::randRange($max, $min);
-        }
-
-        if ($min >= 0)
-            return abs(Rand::random())%($max-$min)+$min;
-        else
-            return (abs(Rand::random())*-1)%($min - $max) + $max;
+        return random_int($min, $max);
     }
-
 
     /**
      * To generate a random string of specified length.
-     * @param int $Length
+     * @param int $length
      * @return String
      */
-    public static function randStr($length=32)
+    public static function randStr($length = 32)
     {
-        /* Use `openssl_random_psuedo_bytes` if available; PHP5 >= 5.3.0 */
-        if (function_exists("openssl_random_pseudo_bytes"))
-        {
-            return substr(bin2hex(openssl_random_pseudo_bytes($length)), 0, $length);
-        }
-
-        /* Fall back to `mcrypt_create_iv`; PHP4, PHP5 */
-        if (function_exists('mcrypt_create_iv'))
-        {
-            return substr(bin2hex(mcrypt_create_iv($length, MCRYPT_DEV_URANDOM)), 0, $length);
-        }
-
-        $sha = ''; $rnd = '';
-        for ($i = 0; $i < $length; $i++)
-        {
-            $sha = hash('sha256', $sha.mt_rand());
-            $char = mt_rand(0,62);
-            $rnd .= $sha[$char];
-        }
-
-        return $rnd;
+        return bin2hex(random_bytes($length));
     }
 }
-
-?>

--- a/libs/core/random.php
+++ b/libs/core/random.php
@@ -44,8 +44,12 @@ final class Rand
      * @param int $max
      * @return number
      */
-    public static function randRange($min = 0, $max = PHP_INT_MAX)
+    public static function randRange($min = 0, $max = null)
     {
+        if (null === $max) {
+            $max = PHP_INT_MAX;
+        }
+
         return random_int($min, $max);
     }
 

--- a/libs/form/csrf/csrf.php
+++ b/libs/form/csrf/csrf.php
@@ -30,7 +30,7 @@ class CSRF
      */
     public function isValidToken($token)
     {
-        return ($token === $this->getToken());
+        return hash_equals($token, $this->getToken());
     }
 
     /**


### PR DESCRIPTION
`random_bytes` and `random_int` should be used for randomness. 

> In order of preference:
> 1. Use libsodium if available.
> 2. fread() /dev/urandom if available (never on Windows)
> 3. mcrypt_create_iv($bytes, MCRYPT_CREATE_IV)
> 4. COM('CAPICOM.Utilities.1')->GetRandom()
> 5. openssl_random_pseudo_bytes() (absolute last resort)
